### PR TITLE
problem: repr calls dumps with the wrong variable name

### DIFF
--- a/csirtg_indicator/indicator.py
+++ b/csirtg_indicator/indicator.py
@@ -226,7 +226,7 @@ class Indicator(object):
             return json.dumps(i, sort_keys=True, indent=4, separators=(',', ': '))
         except UnicodeDecodeError as e:
             i['asn_desc'] = unicode(i['asn_desc'].decode('latin-1'))
-            return json.dumps(o, sort_keys=True, indent=4, separators=(',', ': '))
+            return json.dumps(i, sort_keys=True, indent=4, separators=(',', ': '))
 
 
 def main():


### PR DESCRIPTION
Looks like this bug has existed for a long time, so that exception code
path still might not fully work.