### PR TITLE
Before 1980 is a valid timestamp

### DIFF
--- a/csirtg_indicator/utils/ztime.py
+++ b/csirtg_indicator/utils/ztime.py
@@ -17,7 +17,7 @@ def parse_timestamp(ts):
                 ts = '{}T00:00:00Z'.format(ts)
                 t = arrow.get(ts, 'YYYYMMDDTHH:mm:ss')
 
-            if t.year < 1980:
+            if t.year < 1970:
                 raise RuntimeError('invalid timestamp: %s' % ts)
 
         return t


### PR DESCRIPTION
Can't imagine why a date string like `1970-01-01 00:59:59+01:00` should be invalid...