### PR TITLE
set default group if none provided

### DIFF
--- a/csirtg_indicator/indicator.py
+++ b/csirtg_indicator/indicator.py
@@ -63,6 +63,9 @@ class Indicator(object):
 
         self._count = None
         self.count = kwargs.get('count', 1)
+        
+        self._group = None
+        self.group = kwargs.get('group', 'everyone')
 
         for k in FIELDS_TIME:
             setattr(self, k, kwargs.get(k, None))


### PR DESCRIPTION
When creating an indicator using `csirtg-indicator` or instantiating an `Indicator` object in python, if the group attribute is not provided, the resulting indicator does not include a group by default. 

Example:
`$ csirtg-indicator --indicator example4.com --tags malware`
`{"count": 1,"indicator": "example4.com","tlp": "green","itype": "fqdn","uuid": "271cb3b5-3f1d-4234-8d06-3d6f2884c066","tags": ["malware"]}`

After this change:
`$ csirtg-indicator --indicator example4.com --tags malware`
`{"indicator": "example4.com","itype": "fqdn","tlp": "green","group": "everyone","count": 1,"tags": ["malware"],"uuid": "a5369c3d-5cb7-4b8b-ad86-cdb9a908108b"}`

The group can always be assumed to be "everyone" if no other group is specified.