### PR TITLE
fixed table encodings when using python2

### DIFF
--- a/csirtg_indicator/format/ztable.py
+++ b/csirtg_indicator/format/ztable.py
@@ -33,7 +33,7 @@ def _indicator_row(i, cols, max_field_size):
             if PYVERSION == 2:
                 if isinstance(y, basestring):
                     y = unicode(y)
-                    y = y.encode('utf-8', 'ignore')
+                    y = y.encode('latin-1', 'replace')
             y = str(y)
         y = (y[:max_field_size] + '..') if len(y) > max_field_size else y
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 coverage>=4.2
 pytest>=2.9.1
-pytest-cov>=2.2.1
+pytest-cov>=2.4.0,<2.6
 wheel
 -r requirements.txt

--- a/test/format/test_table.py
+++ b/test/format/test_table.py
@@ -13,14 +13,14 @@ def indicator():
             'tlp': "amber",
             'confidence': "85",
             'reporttime': '2015-01-01T00:00:00Z',
-            'asn_desc': u'telefÔnica brasil'
+            'asn_desc': u'telefÔnica brasilá',
         }
     return Indicator(**i)
 
 
 @pytest.fixture
 def indicator_unicode(indicator):
-    indicator.indicator = 'http://xz.job391.com/down/ï¿½ï¿½ï¿½ï¿½à¿ªï¿½ï¿½@89_1_60'
+    indicator.indicator = 'http://xz.job391.com/down/ï¿½ï¿½ï¿½ï¿½à¿ªï¿½ï¿½@89_1_60á'
     return indicator
 
 


### PR DESCRIPTION
When running cif with python2 if you encounter a unicode character, pretty tables blows up. This fixes the encoding.