### PR TITLE
fix: consistent output on csv lines

### DIFF
--- a/csirtg_indicator/format/zcsv.py
+++ b/csirtg_indicator/format/zcsv.py
@@ -54,7 +54,7 @@ class Csv(Plugin):
 
     def __repr__(self):
         output = StringIO()
-        
+
         csvWriter = csv.DictWriter(output, self.cols, quoting=csv.QUOTE_ALL)
         csvWriter.writeheader()
 
@@ -87,5 +87,6 @@ class Csv(Plugin):
 
 
             csvWriter.writerow(r)
-        
-        return output.getvalue().strip('\r\n')
+
+        return output.getvalue().strip('\n')
+    

--- a/csirtg_indicator/format/zcsv.py
+++ b/csirtg_indicator/format/zcsv.py
@@ -89,4 +89,3 @@ class Csv(Plugin):
             csvWriter.writerow(r)
 
         return output.getvalue().strip('\n')
-    


### PR DESCRIPTION
Every line but the final one was a \r\n, the last line was just \n. This made certain parsing of the output less easy because it wasn't consistent. This just stops stripping the \r from the final line so they all are consistent.