### PR TITLE
pin arrow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow>=0.7.0
+arrow>=0.7.0,<=0.14.2
 pytricia>=0.9.0
 ipaddress>=1.0.16
 pendulum>=0.5.2


### PR DESCRIPTION
fixes 'invalid attribute days' error in csirtg-smrt by pinning arrow version